### PR TITLE
Fix SAE-J1850 Configuration

### DIFF
--- a/docs/docs/changelog/unreleased.md
+++ b/docs/docs/changelog/unreleased.md
@@ -1,5 +1,14 @@
 # Unreleased
 
+## 🐞 Bug Fix
+* Adjusted the SAE-J1850 configuration to match the specification
+    
+    🚨️ For users which do rely on the previously misconfigured `SAEJ1850` settings a configuration named `SAE_J1850_ZERO` was added.
+
+##  Breaking Changes
+* Remove Python 3.7 support
+
 ## 🔩  Internal / Development
 * Add `python 3.12` to test matrix
 * Re-lock dev dependencies
+

--- a/src/crc/_crc.py
+++ b/src/crc/_crc.py
@@ -154,8 +154,8 @@ class Configuration:
         saej1850 = Configuration(
             width=8,
             polynomial=0x1D,
-            init_value=0,
-            final_xor_value=0,
+            init_value=0xFF,
+            final_xor_value=0xFF,
             reverse_input=False,
             reverse_output=False
         )
@@ -435,6 +435,15 @@ class Crc8(enum.Enum):
     )
 
     SAEJ1850 = Configuration(
+        width=8,
+        polynomial=0x1D,
+        init_value=0xFF,
+        final_xor_value=0xFF,
+        reverse_input=False,
+        reverse_output=False,
+    )
+
+    SAEJ1850_ZERO = Configuration(
         width=8,
         polynomial=0x1D,
         init_value=0x00,

--- a/test/unit/test_crc.py
+++ b/test/unit/test_crc.py
@@ -210,6 +210,22 @@ class RegisterTest(unittest.TestCase):
             crc_register = register_type(config)
             test_suit = [
                 Fixture(data="", checksum=0x00),
+                Fixture(data=string.digits[1:], checksum=0x4B),
+                Fixture(data=string.digits[1:][::-1], checksum=0xD6),
+                Fixture(data=string.digits, checksum=0x74),
+                Fixture(data=string.digits[::-1], checksum=0xC7),
+            ]
+            for test in test_suit:
+                crc_register.init()
+                crc_register.update(test.data.encode("utf-8"))
+                self.assertEqual(test.checksum, crc_register.digest())
+
+    def test_crc8_saej1850_zero(self):
+        config = Crc8.SAEJ1850_ZERO
+        for register_type in self._register_types:
+            crc_register = register_type(config)
+            test_suit = [
+                Fixture(data="", checksum=0x00),
                 Fixture(data=string.digits[1:], checksum=0x37),
                 Fixture(data=string.digits[1:][::-1], checksum=0xAA),
                 Fixture(data=string.digits, checksum=0x8A),


### PR DESCRIPTION
Fixes #127 

Update the SAE-J1850 configuration to align with the specification.
Additionally, introduce a configuration named SAE-J1850_ZERO as a replacement
for users who might rely on the previously misconfigured SAE-J1850 configuration.


