### PR TITLE
Adds a new configuration for CRC16 IBM-3740

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ For convince various frequently used crc configurations ship with the library ou
 | AUTOSAR | GSM      | AUTOSAR | |
 | SAJ1850 | PROFIBUS | BZIP2 | |
 | BLUETOOTH | MODBUS   | POSIX | |
-| MAXIM-DOW |          | | | |
+| MAXIM-DOW | IBM-3740 | | | |
 
 If you find yourself in the position, where having a new configuration available out of the
 box would be desirable, feel free to create a [PR](https://github.com/Nicoretti/crc/pulls) or file an [issue](https://github.com/Nicoretti/crc/issues).

--- a/docs/docs/changelog/unreleased.md
+++ b/docs/docs/changelog/unreleased.md
@@ -1,1 +1,3 @@
 # Unreleased
+## ✨ Features
+* Add support for IBM-3740 (also known as CCITT-FALSE)

--- a/docs/docs/contributors.md
+++ b/docs/docs/contributors.md
@@ -3,6 +3,7 @@
 Thank you to all contributors for your help in improving this project. 🚀
 
 * Gert van Dijk
+* Riccardo Malavolti
 * Dependabot
 
 

--- a/src/crc/_crc.py
+++ b/src/crc/_crc.py
@@ -518,6 +518,15 @@ class Crc16(enum.Enum):
         reverse_output=True,
     )
 
+    IBM_3740 = Configuration(
+        width=16,
+        polynomial=0x1021,
+        init_value=0x0000,
+        final_xor_value=0x0000,
+        reverse_input=False,
+        reverse_output=False,
+    )
+
 
 @enum.unique
 class Crc32(enum.Enum):

--- a/src/crc/_crc.py
+++ b/src/crc/_crc.py
@@ -521,7 +521,7 @@ class Crc16(enum.Enum):
     IBM_3740 = Configuration(
         width=16,
         polynomial=0x1021,
-        init_value=0xffff,
+        init_value=0xFFFF,
         final_xor_value=0x0000,
         reverse_input=False,
         reverse_output=False,

--- a/src/crc/_crc.py
+++ b/src/crc/_crc.py
@@ -521,7 +521,7 @@ class Crc16(enum.Enum):
     IBM_3740 = Configuration(
         width=16,
         polynomial=0x1021,
-        init_value=0x0000,
+        init_value=0xffff,
         final_xor_value=0x0000,
         reverse_input=False,
         reverse_output=False,

--- a/test/unit/test_crc.py
+++ b/test/unit/test_crc.py
@@ -283,7 +283,6 @@ class RegisterTest(unittest.TestCase):
                 crc_register.init()
                 crc_register.update(test.data.encode("utf-8"))
                 self.assertEqual(test.checksum, crc_register.digest())
-            
 
     def test_crc16_with_reflected_input(self):
         config = Configuration(16, 0x1021, 0, 0, True, False)

--- a/test/unit/test_crc.py
+++ b/test/unit/test_crc.py
@@ -268,6 +268,23 @@ class RegisterTest(unittest.TestCase):
                 crc_register.update(test.data.encode("utf-8"))
                 self.assertEqual(test.checksum, crc_register.digest())
 
+    def test_cr16_ibm_3740(self):
+        config = Crc16.IBM_3740
+        for register_type in self._register_types:
+            crc_register = register_type(config)
+            test_suit = [
+                Fixture(data="", checksum=0xFFFF),
+                Fixture(data=string.digits[1:], checksum=0x29B1),
+                Fixture(data=string.digits[1:][::-1], checksum=0x84DF),
+                Fixture(data=string.digits, checksum=0x7D61),
+                Fixture(data=string.digits[::-1], checksum=0x385F),
+            ]
+            for test in test_suit:
+                crc_register.init()
+                crc_register.update(test.data.encode("utf-8"))
+                self.assertEqual(test.checksum, crc_register.digest())
+            
+
     def test_crc16_with_reflected_input(self):
         config = Configuration(16, 0x1021, 0, 0, True, False)
         for register_type in self._register_types:


### PR DESCRIPTION
Hi guys, I had to create a new configuration for this esoteric flavour, if you find it useful feel free to merge this request.

Values are taken from [the crc catalogue linked in README](https://reveng.sourceforge.io/crc-catalogue/all.htm) and seem to be ok with other implementations.

```
width=16 poly=0x1021 init=0xffff refin=false refout=false xorout=0x0000 check=0x29b1 residue=0x0000
```

Let me know if you need a test case or anything else.

Great work btw!