### PR TITLE
Draft: Add support for bytes convertible types

### DIFF
--- a/src/crc/_crc.py
+++ b/src/crc/_crc.py
@@ -11,17 +11,32 @@ import numbers
 import sys
 from dataclasses import dataclass
 from typing import (
+    Protocol,
     BinaryIO,
     Final,
     Iterable,
     Iterator,
     Union,
+    Any,
 )
 
 __author__ = [
     "Nicola Coretti <nico.coretti@gmail.com>",
     "Gert van Dijk <github@gertvandijk.nl>",
 ]
+
+class ByteConvertible(Protocol):
+    """Anything which implements __bytes__"""
+
+    def __bytes__(self) -> bytes:
+        pass
+
+def is_byte_convertible(d: Any) -> bool:
+    try:
+        bytes(d)
+    except TypeError:
+        return False
+    return True
 
 InputType = Union[
     int,
@@ -30,6 +45,7 @@ InputType = Union[
     memoryview,
     BinaryIO,
     Iterable[Union[bytes, bytearray, memoryview]],
+    ByteConvertible,
 ]
 """Type alias for acceptable input types for [Calculator][crc.Calculator]."""
 
@@ -418,6 +434,8 @@ def _bytes_generator(data: InputType) -> Iterable[bytes]:
         yield bytes(data)
     elif isinstance(data, (Iterable, BinaryIO)):
         yield from (bytes(e) for e in data)
+    elif is_byte_convertible(data):
+        yield bytes(data)
     else:
         raise TypeError(f"Unsupported parameter type: {type(data)}")
 

--- a/src/crc/_crc.py
+++ b/src/crc/_crc.py
@@ -11,13 +11,13 @@ import numbers
 import sys
 from dataclasses import dataclass
 from typing import (
-    Protocol,
+    Any,
     BinaryIO,
     Final,
     Iterable,
     Iterator,
+    Protocol,
     Union,
-    Any,
 )
 
 __author__ = [
@@ -25,11 +25,13 @@ __author__ = [
     "Gert van Dijk <github@gertvandijk.nl>",
 ]
 
+
 class ByteConvertible(Protocol):
     """Anything which implements __bytes__"""
 
     def __bytes__(self) -> bytes:
         pass
+
 
 def is_byte_convertible(d: Any) -> bool:
     try:
@@ -37,6 +39,7 @@ def is_byte_convertible(d: Any) -> bool:
     except TypeError:
         return False
     return True
+
 
 InputType = Union[
     int,

--- a/test/unit/test_crc.py
+++ b/test/unit/test_crc.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2018, Nicola Coretti
 # All rights reserved.
 import io
+import array
 import string
 import unittest
 from collections import namedtuple
@@ -491,6 +492,29 @@ class CalculatorTest(unittest.TestCase):
 def test_calculator_with_different_input_types(config, data, expected):
     calculator = Calculator(config)
     assert calculator.checksum(data) == expected
+
+
+class TestByteConvertibleSupport:
+
+    @pytest.fixture
+    def calculator(self):
+        return Calculator(Crc8.CCITT)
+
+    class ByteConvertibleType:
+        def __bytes__(self) -> bytes:
+            return b"123456789"
+
+    @pytest.mark.parametrize(
+        "data,expected",
+        [
+            (ByteConvertibleType(), 0xF4),
+            ([49, 50, 51, 52, 53, 54, 55, 56, 57] , 0xF4), # NOTE: does not work matches with iterable branch
+            (array.array('B', b"123456789"), 0xF4) # NOTE:  does not work matches with iterable branch
+        ],
+        ids=type
+    )
+    def test_custom_byte_convertible_type(self, calculator, data, expected):
+        assert calculator.checksum(data) == expected
 
 
 @pytest.mark.parametrize(

--- a/test/unit/test_crc.py
+++ b/test/unit/test_crc.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2018, Nicola Coretti
 # All rights reserved.
-import io
 import array
+import io
 import string
 import unittest
 from collections import namedtuple
@@ -508,10 +508,16 @@ class TestByteConvertibleSupport:
         "data,expected",
         [
             (ByteConvertibleType(), 0xF4),
-            ([49, 50, 51, 52, 53, 54, 55, 56, 57] , 0xF4), # NOTE: does not work matches with iterable branch
-            (array.array('B', b"123456789"), 0xF4) # NOTE:  does not work matches with iterable branch
+            (
+                [49, 50, 51, 52, 53, 54, 55, 56, 57],
+                0xF4,
+            ),  # NOTE: does not work matches with iterable branch
+            (
+                array.array("B", b"123456789"),
+                0xF4,
+            ),  # NOTE:  does not work matches with iterable branch
         ],
-        ids=type
+        ids=type,
     )
     def test_custom_byte_convertible_type(self, calculator, data, expected):
         assert calculator.checksum(data) == expected


### PR DESCRIPTION
 ## 🧪 Experimental

 This PR is a work-in-progress exploring ways to enhance the calculator with support for additional input types that can be converted to bytes. Examples include lists of integers or array.array['B'] types.

 ### Challenges:
 - Maintaining strong typing support while adding flexibility
 - Supporting user-defined types that implement byte conversion

 ### Proposed Approach:
 1. Implement type checking for bytes conversion capability (via `bytes()` or `__bytes__` method)
 2. Add protocol or abstract type support to enable custom user types

 ### Questions:
 - How mark built-in types so typing works well
 - Should this be introduced as a "beta" feature with a new calculator implementation?
 - How to balance flexibility with type safety?

